### PR TITLE
Show scrollbar when diff overflows

### DIFF
--- a/src/components/EditableDiff/index.vue
+++ b/src/components/EditableDiff/index.vue
@@ -105,6 +105,7 @@ export default {
   background-color: #E4F1FE;
   display: flex;
   font-family: 'Courier New', Courier, monospace;
+  overflow: auto;
   padding: 0 1em;
   textarea {
     width: 100%;


### PR DESCRIPTION
Before:

![diff without scrollbar](https://user-images.githubusercontent.com/6563664/96351122-e5bf4600-10a8-11eb-8b2e-a97cda3de8db.png)

After

![diff with scrollbar](https://user-images.githubusercontent.com/6563664/96351151-0daea980-10a9-11eb-810d-951fa5507e0e.png)
