### PR TITLE
Add regression management views

### DIFF
--- a/src/api/regressions.js
+++ b/src/api/regressions.js
@@ -1,0 +1,24 @@
+import request from '@/utils/system/request.js'
+
+export function fetchRegressions(params) {
+  return request({
+    url: '/api/regressions',
+    method: 'get',
+    params
+  })
+}
+
+export function fetchRegression(id) {
+  return request({
+    url: `/api/regressions/${id}`,
+    method: 'get'
+  })
+}
+
+export function updateRegression(id, data) {
+  return request({
+    url: `/api/regressions/${id}`,
+    method: 'patch',
+    data
+  })
+}

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -11,6 +11,7 @@ import { createNameComponent } from './createNode'
 import Dashboard from './modules/dashboard'
 import Games from './modules/games'
 import Installers from './modules/installers'
+import Regressions from './modules/regressions'
 import System, { catchAllRoute } from './modules/system'
 
 let modules = [...System]
@@ -21,7 +22,7 @@ const router = createRouter({
   history: createWebHashHistory(),
   routes
 })
-let asyncRoutes = [...Dashboard, ...Games, ...Installers]
+let asyncRoutes = [...Dashboard, ...Games, ...Installers, ...Regressions]
 
 let routesInitialized = false
 

--- a/src/router/modules/regressions.js
+++ b/src/router/modules/regressions.js
@@ -1,0 +1,28 @@
+import Layout from '@/layout/index.vue'
+import { createNameComponent } from '../createNode'
+const route = [
+  {
+    path: '/regressions',
+    component: Layout,
+    redirect: '/regressions/list',
+    meta: { title: 'Regressions', icon: 'WarningFilled' },
+    alwayShow: true,
+    children: [
+      {
+        path: 'list',
+        component: createNameComponent(() => import('@/views/regressions/list.vue')),
+        name: 'RegressionList',
+        meta: { title: 'Regressions', noCache: true }
+      },
+      {
+        path: ':id',
+        component: createNameComponent(() => import('@/views/regressions/detail.vue')),
+        name: 'RegressionDetail',
+        meta: { title: 'Regression Detail', noCache: true },
+        hideMenu: true
+      }
+    ]
+  }
+]
+
+export default route

--- a/src/views/regressions/detail.vue
+++ b/src/views/regressions/detail.vue
@@ -1,0 +1,189 @@
+<template>
+  <div class="app-container" v-loading="loading">
+    <template v-if="regression">
+      <div class="header">
+        <h1>{{ regression.title }}</h1>
+        <el-tag :type="statusTagType(regression.status)" size="large">
+          {{ regression.status }}
+        </el-tag>
+      </div>
+
+      <el-descriptions :column="2" border style="margin-bottom: 20px;">
+        <el-descriptions-item label="Submitted by">{{ regression.submitted_by }}</el-descriptions-item>
+        <el-descriptions-item label="Reviewed by">{{ regression.reviewed_by || '—' }}</el-descriptions-item>
+        <el-descriptions-item label="Wine Version">{{ regression.last_known_working_version }}</el-descriptions-item>
+        <el-descriptions-item label="Bug Status">{{ regression.bug_status || '—' }}</el-descriptions-item>
+        <el-descriptions-item label="Created">{{ formatDate(regression.created_at) }}</el-descriptions-item>
+        <el-descriptions-item label="Updated">{{ formatDate(regression.updated_at) }}</el-descriptions-item>
+        <el-descriptions-item v-if="regression.resolved_at" label="Resolved">{{ formatDate(regression.resolved_at) }}</el-descriptions-item>
+        <el-descriptions-item v-if="regression.bug_url" label="Bug URL" :span="2">
+          <a :href="regression.bug_url" target="_blank" class="bug-link">{{ regression.bug_url }}</a>
+        </el-descriptions-item>
+      </el-descriptions>
+
+      <div v-if="regression.description" class="description">
+        <h3>Description</h3>
+        <p>{{ regression.description }}</p>
+      </div>
+
+      <div class="section">
+        <h3>Affected Games ({{ regression.games.length }})</h3>
+        <el-table :data="regression.games" fit size="small" v-if="regression.games.length">
+          <el-table-column label="Name" min-width="200">
+            <template #default="{ row }">
+              <router-link :to="'/games/' + row.slug" class="game-link">{{ row.name }}</router-link>
+            </template>
+          </el-table-column>
+          <el-table-column label="Slug" width="200" prop="slug" />
+        </el-table>
+        <p v-else class="text-muted">No games linked yet.</p>
+      </div>
+
+      <el-divider />
+
+      <h3>Edit</h3>
+      <el-form label-width="180px" style="max-width: 700px;">
+        <el-form-item label="Title">
+          <el-input v-model="editForm.title" />
+        </el-form-item>
+        <el-form-item label="Description">
+          <el-input v-model="editForm.description" type="textarea" :rows="4" />
+        </el-form-item>
+        <el-form-item label="Bug URL">
+          <el-input v-model="editForm.bug_url" />
+        </el-form-item>
+        <el-form-item label="Bug Status">
+          <el-input v-model="editForm.bug_status" placeholder="e.g. open, fixed, wontfix" />
+        </el-form-item>
+        <el-form-item label="Wine Version">
+          <el-input v-model="editForm.last_known_working_version" />
+        </el-form-item>
+        <el-form-item label="Status">
+          <el-select v-model="editForm.status">
+            <el-option value="pending" label="Pending" />
+            <el-option value="accepted" label="Accepted" />
+            <el-option value="rejected" label="Rejected" />
+            <el-option value="resolved" label="Resolved" />
+          </el-select>
+        </el-form-item>
+        <el-form-item>
+          <el-button type="primary" @click="onSave" :loading="saving">Save</el-button>
+        </el-form-item>
+      </el-form>
+    </template>
+  </div>
+</template>
+
+<script>
+import { fetchRegression, updateRegression } from '@/api/regressions'
+import { ElMessage } from 'element-plus'
+import dayjs from 'dayjs'
+
+export default {
+  name: 'RegressionDetail',
+  data() {
+    return {
+      regression: null,
+      loading: false,
+      saving: false,
+      editForm: {
+        title: '',
+        description: '',
+        bug_url: '',
+        bug_status: '',
+        last_known_working_version: '',
+        status: ''
+      }
+    }
+  },
+  created() {
+    this.loadRegression()
+  },
+  methods: {
+    loadRegression() {
+      this.loading = true
+      fetchRegression(this.$route.params.id).then(response => {
+        this.regression = response.data
+        this.editForm = {
+          title: this.regression.title,
+          description: this.regression.description,
+          bug_url: this.regression.bug_url,
+          bug_status: this.regression.bug_status,
+          last_known_working_version: this.regression.last_known_working_version,
+          status: this.regression.status
+        }
+        this.loading = false
+      })
+    },
+
+    formatDate(dateStr) {
+      if (!dateStr) return ''
+      return dayjs(dateStr).format('YYYY-MM-DD HH:mm')
+    },
+
+    statusTagType(status) {
+      switch (status) {
+        case 'pending': return 'warning'
+        case 'accepted': return 'success'
+        case 'rejected': return 'danger'
+        case 'resolved': return 'info'
+        default: return ''
+      }
+    },
+
+    onSave() {
+      this.saving = true
+      updateRegression(this.regression.id, this.editForm).then(response => {
+        this.regression = response.data
+        ElMessage.success('Regression updated')
+        this.saving = false
+      }).catch(() => {
+        this.saving = false
+      })
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.header {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  margin-bottom: 20px;
+
+  h1 {
+    margin: 0;
+  }
+}
+
+.description {
+  margin-bottom: 20px;
+
+  p {
+    white-space: pre-wrap;
+  }
+}
+
+.section {
+  margin-bottom: 20px;
+}
+
+.game-link {
+  color: var(--system-primary-color);
+  text-decoration: none;
+
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
+.bug-link {
+  color: var(--system-primary-color);
+  word-break: break-all;
+}
+
+.text-muted {
+  color: var(--system-page-tip-color);
+}
+</style>

--- a/src/views/regressions/list.vue
+++ b/src/views/regressions/list.vue
@@ -1,0 +1,150 @@
+<template>
+  <div class="app-container">
+    <h1>Regressions</h1>
+
+    <el-radio-group v-model="statusFilter" style="margin-bottom: 16px;" @change="loadRegressions">
+      <el-radio-button value="">All</el-radio-button>
+      <el-radio-button value="pending">Pending</el-radio-button>
+      <el-radio-button value="accepted">Accepted</el-radio-button>
+      <el-radio-button value="rejected">Rejected</el-radio-button>
+      <el-radio-button value="resolved">Resolved</el-radio-button>
+    </el-radio-group>
+
+    <el-table
+      v-loading="loading"
+      key="id"
+      :data="regressions"
+      fit
+      highlight-current-row>
+      <el-table-column label="Title" min-width="250">
+        <template #default="{ row }">
+          <router-link :to="'/regressions/' + row.id" class="regression-link">
+            {{ row.title }}
+          </router-link>
+        </template>
+      </el-table-column>
+      <el-table-column label="Status" width="130">
+        <template #default="{ row }">
+          <el-tag :type="statusTagType(row.status)" size="small">
+            {{ row.status }}
+          </el-tag>
+        </template>
+      </el-table-column>
+      <el-table-column label="Wine Version" width="180" prop="last_known_working_version" />
+      <el-table-column label="Games" width="100" align="center">
+        <template #default="{ row }">
+          {{ row.games.length }}
+        </template>
+      </el-table-column>
+      <el-table-column label="Submitted by" width="140" prop="submitted_by" />
+      <el-table-column label="Date" width="120">
+        <template #default="{ row }">
+          <span class="date-cell" :title="row.created_at">{{ formatDate(row.created_at) }}</span>
+        </template>
+      </el-table-column>
+      <el-table-column label="Actions" width="260" align="center">
+        <template #default="{ row }">
+          <template v-if="row.status === 'pending'">
+            <el-button type="success" size="small" @click="onAccept(row)">Accept</el-button>
+            <el-button type="danger" size="small" @click="onReject(row)">Reject</el-button>
+          </template>
+          <template v-else-if="row.status === 'accepted'">
+            <el-button type="warning" size="small" @click="onResolve(row)">Resolve</el-button>
+            <el-button type="danger" size="small" @click="onReject(row)">Reject</el-button>
+          </template>
+          <template v-else-if="row.status === 'rejected'">
+            <el-button type="success" size="small" @click="onAccept(row)">Accept</el-button>
+          </template>
+          <template v-else-if="row.status === 'resolved'">
+            <el-button type="success" size="small" @click="onAccept(row)">Reopen</el-button>
+          </template>
+        </template>
+      </el-table-column>
+    </el-table>
+  </div>
+</template>
+
+<script>
+import { fetchRegressions, updateRegression } from '@/api/regressions'
+import dayjs from 'dayjs'
+import relativeTime from 'dayjs/plugin/relativeTime'
+
+dayjs.extend(relativeTime)
+
+export default {
+  name: 'RegressionList',
+  data() {
+    return {
+      regressions: [],
+      loading: false,
+      statusFilter: 'pending'
+    }
+  },
+  created() {
+    this.loadRegressions()
+  },
+  methods: {
+    loadRegressions() {
+      this.loading = true
+      const params = {}
+      if (this.statusFilter) {
+        params.status = this.statusFilter
+      }
+      fetchRegressions(params).then(response => {
+        this.regressions = response.data.results
+        this.loading = false
+      })
+    },
+
+    formatDate(dateStr) {
+      if (!dateStr) return ''
+      return dayjs(dateStr).fromNow()
+    },
+
+    statusTagType(status) {
+      switch (status) {
+        case 'pending': return 'warning'
+        case 'accepted': return 'success'
+        case 'rejected': return 'danger'
+        case 'resolved': return 'info'
+        default: return ''
+      }
+    },
+
+    onAccept(row) {
+      updateRegression(row.id, { status: 'accepted' }).then(response => {
+        Object.assign(row, response.data)
+      })
+    },
+
+    onReject(row) {
+      updateRegression(row.id, { status: 'rejected' }).then(response => {
+        Object.assign(row, response.data)
+      })
+    },
+
+    onResolve(row) {
+      updateRegression(row.id, { status: 'resolved' }).then(response => {
+        Object.assign(row, response.data)
+      })
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.regression-link {
+  color: var(--system-primary-color);
+  text-decoration: none;
+  font-weight: 500;
+
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
+.date-cell {
+  font-size: 12px;
+  color: var(--system-page-tip-color);
+}
+</style>


### PR DESCRIPTION
List and detail views for moderating Proton/Wine regressions with inline accept/reject/resolve actions and an edit form for all fields.